### PR TITLE
Fix type import and add test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Testing
+
+Install dependencies and run the test suite with:
+
+```bash
+npm install
+npm test --silent
+```
+
+Tests are executed using [Jest](https://jestjs.io/).

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -20,7 +21,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <html lang="es" className={`${geistSans.variable} ${geistMono.variable}`}>


### PR DESCRIPTION
## Summary
- fix missing ReactNode type import in RootLayout
- add instructions for running unit tests to README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6862a7c5fb5c83268475bedc9f19275e