### PR TITLE
Add middleware and unit tests

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { GoogleAuthService } from "@/lib/google/auth";
+
+const googleAuthService = new GoogleAuthService(
+  process.env.GOOGLE_CLIENT_ID || "",
+  process.env.GOOGLE_CLIENT_SECRET || "",
+  process.env.GOOGLE_REDIRECT_URI || "",
+);
+
+function parseEmail(token: string): string | null {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+
+    const padded = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const json = Buffer.from(padded, "base64").toString();
+    const { email } = JSON.parse(json);
+    return email || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function middleware(req: NextRequest) {
+  void req;
+  const token = await googleAuthService.getAccessToken();
+  const email = token ? parseEmail(token) : null;
+
+  if (!token || !email) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const res = NextResponse.next();
+  res.headers.set("x-user-email", email);
+  return res;
+}
+
+export const matcher = ["/api/:path*"];
+export { googleAuthService };

--- a/src/tests/unit/middleware.spec.ts
+++ b/src/tests/unit/middleware.spec.ts
@@ -1,0 +1,61 @@
+import { jest } from "@jest/globals";
+
+// Mock the next/server module to avoid requiring Next.js runtime
+jest.mock("next/server", () => {
+  class MockNextRequest {
+    constructor(public request?: unknown) {}
+  }
+  class MockResponse {
+    status = 200;
+    headers = new Headers();
+  }
+  return {
+    NextResponse: {
+      next: () => new MockResponse(),
+      json: (_body: unknown, init?: { status?: number }) => {
+        const res = new MockResponse();
+        if (init?.status) res.status = init.status;
+        return res;
+      },
+    },
+    NextRequest: MockNextRequest,
+  };
+});
+
+// Mock GoogleAuthService to avoid importing googleapis
+jest.mock("@/lib/google/auth", () => {
+  return {
+    GoogleAuthService: jest.fn().mockImplementation(() => ({
+      getAccessToken: jest.fn(),
+    })),
+  };
+});
+
+import { middleware, googleAuthService } from "@/middleware";
+import { NextRequest } from "next/server";
+
+// Jest unit tests for the middleware
+
+describe("middleware", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns 401 when token missing", async () => {
+    jest.spyOn(googleAuthService, "getAccessToken").mockResolvedValueOnce(null);
+    const req = new NextRequest();
+    const res = await middleware(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("sets header on success", async () => {
+    const payload = { email: "user@example.com" };
+    const token = `a.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.c`;
+    jest
+      .spyOn(googleAuthService, "getAccessToken")
+      .mockResolvedValueOnce(token);
+    const req = new NextRequest();
+    const res = await middleware(req);
+    expect(res.headers.get("x-user-email")).toBe("user@example.com");
+  });
+});


### PR DESCRIPTION
## Summary
- implement token parsing logic for API middleware
- mock Next.js modules and GoogleAuthService for jest
- convert middleware tests from Vitest to Jest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862b69ce5ec83269047e31e101d1978