### PR TITLE
Add Google login page

### DIFF
--- a/src/app/(auth)/login/LoginButton.tsx
+++ b/src/app/(auth)/login/LoginButton.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useGoogleAuth } from "@/hooks/useGoogleAuth";
+import { useRouter } from "next/navigation";
+
+export default function LoginButton() {
+  const router = useRouter();
+  const auth = useGoogleAuth();
+
+  const handleClick = async () => {
+    await auth.login();
+    router.push("/");
+  };
+
+  return (
+    <Button aria-label="Sign in with Google" onClick={handleClick}>
+      Sign in with Google
+    </Button>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,12 @@
+import { Card } from "@/components/ui/card";
+import LoginButton from "./LoginButton";
+
+export default function LoginPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center p-6">
+      <Card className="p-6">
+        <LoginButton />
+      </Card>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add `(auth)/login` page using Shadcn Card with a LoginButton
- implement LoginButton client component using useGoogleAuth hook

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6862cfa4af4c8326bb3c289ca80d39d0