### PR TITLE
Add global SessionProvider

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import NextAuthProvider from "./providers/SessionProvider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -18,17 +21,18 @@ export const metadata: Metadata = {
   description: "MVP para registrar y analizar gastos",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: ReactNode;
 }) {
+  const session = await getServerSession(authOptions);
   return (
     <html lang="es" className={`${geistSans.variable} ${geistMono.variable}`}>
       {/* 1️⃣ Añadimos ambas variables y la clase tailwind "font-sans" */}
       <body className="font-sans antialiased bg-white text-neutral-900">
         {/* 2️⃣ ¡Renderizamos los hijos! */}
-        {children}
+        <NextAuthProvider session={session}>{children}</NextAuthProvider>
       </body>
     </html>
   );

--- a/src/app/providers/SessionProvider.tsx
+++ b/src/app/providers/SessionProvider.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { SessionProvider } from "next-auth/react";
+import type { Session } from "next-auth";
+
+export default function NextAuthProvider({
+  children,
+  session,
+}: {
+  children: React.ReactNode;
+  session: Session | null;
+}) {
+  return <SessionProvider session={session}>{children}</SessionProvider>;
+}


### PR DESCRIPTION
## Summary
- create NextAuthProvider for app router
- wrap children in SessionProvider in RootLayout

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68642435749c8326a40da46ecd0b3cf7